### PR TITLE
Fix firmware update action

### DIFF
--- a/src/com/jpos/POStest/FirmwareUpdateDlg.java
+++ b/src/com/jpos/POStest/FirmwareUpdateDlg.java
@@ -213,7 +213,7 @@ public class FirmwareUpdateDlg extends JDialog implements ActionListener, Status
             if(compareRadio.isSelected()){
                 try{
                     int[] result = new int[1];
-                    Object[] args = new Object[1];
+                    Object[] args = new Object[2];
                     args[0] = fileNameTF.getText();
                     args[1] = result;
                     compareMethod.invoke(deviceObject, args);


### PR DESCRIPTION
There're two array entries in an array of size 1, that's obviously a mistake that causes unhandled exception in my test cases